### PR TITLE
Check for finished status before getting finished_at time

### DIFF
--- a/nevermined_compute_api/routes.py
+++ b/nevermined_compute_api/routes.py
@@ -180,7 +180,8 @@ def get_status(execution_id):
             result = {
                 "status": status.phase,
                 "startedAt": status.started_at.isoformat(timespec="seconds") + "Z",
-                "finishedAt": status.finished_at.isoformat(timespec="seconds") + "Z",
+                "finishedAt": status.finished_at.isoformat(timespec="seconds") + "Z" \
+                    if status.finished_at else None,
                 "did": None,
                 "pods": []
             }
@@ -189,7 +190,8 @@ def get_status(execution_id):
                 "podName": pod_name,
                 "status": status.phase,
                 "startedAt": status.started_at.isoformat(timespec="seconds") + "Z",
-                "finishedAt": status.finished_at.isoformat(timespec="seconds") + "Z"
+                "finishedAt": status.finished_at.isoformat(timespec="seconds") + "Z" \
+                    if status.finished_at else None,
             }
             pods.append(status_message)
 


### PR DESCRIPTION
## Description

- The `finished_at` key is set to `None` before the pod finishes. Add a check before trying to convert the time

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation