### PR TITLE
Use docker images under neverminedio instead of keykoio

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,7 +39,7 @@ jobs:
         touch ${HOME}/.nevermined/nevermined-contracts/artifacts/ready
 
         # start minikube
-        ./scripts/setup_minikube.sh
+        MINIKUBE_DRIVER=docker ./scripts/setup_minikube.sh
         cd ..
 
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,8 +32,13 @@ jobs:
       run: |
         docker login -u ${{ secrets.NEVERMINED_DOCKER_USERNAME }} -p ${{ secrets.NEVERMINED_DOCKER_TOKEN}}
         git clone https://github.com/nevermined-io/tools nevermined-tools
-
         cd nevermined-tools
+
+        # mock artifacts ready since they are not neeeded to run the tests
+        mkdir -p $HOME/.nevermined/nevermined-contracts/artifacts
+        touch ${HOME}/.nevermined/nevermined-contracts/artifacts/ready
+
+        # start minikube
         ./scripts/setup_minikube.sh
         cd ..
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,20 +21,26 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: setup-minikube
-      uses: medyagh/setup-minikube@v0.0.2
-    - name: Set up argo
+
+    - name: Install minikube v1.12.0
       run: |
-        curl -sLO https://github.com/argoproj/argo/releases/download/v2.8.1/argo-linux-amd64
-        chmod +x argo-linux-amd64
-        sudo mv ./argo-linux-amd64 /usr/local/bin/argo
-        kubectl create namespace nevermined-compute
-        kubectl apply -n nevermined-compute -f https://raw.githubusercontent.com/argoproj/argo/stable/manifests/install.yaml
-#    - name: Debugging with tmate
-#      uses: mxschmitt/action-tmate@v2
+        wget https://storage.googleapis.com/minikube/releases/v1.12.0/minikube-linux-amd64
+        chmod +x minikube-linux-amd64
+        sudo mv minikube-linux-amd64 /usr/local/bin/minikube
+
+    - name: Setup minikube
+      run: |
+        docker login -u ${{ secrets.NEVERMINED_DOCKER_USERNAME }} -p ${{ secrets.NEVERMINED_DOCKER_TOKEN}}
+        git clone https://github.com/nevermined-io/tools nevermined-tools
+
+        cd nevermined-tools
+        ./scripts/setup_minikube.sh
+        cd ..
+
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        pip install pip==20.2.4
         pip install -r requirements_dev.txt
     - name: Test with pytest
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 COPY . /nevermined-compute-api
 WORKDIR /nevermined-compute-api
 
+RUN pip install pip==20.2.4
 RUN pip install .
 
 # config.ini configuration file variables

--- a/nevermined_compute_api/argo-workflow.yaml
+++ b/nevermined_compute_api/argo-workflow.yaml
@@ -92,7 +92,7 @@ spec:
 
   - name: configuratorPod
     container:
-      image: keykoio/nevermined-pod-config-py
+      image: neverminedio/pod-config-py:latest
       imagePullPolicy: IfNotPresent
       name: configuratorPod
       command:
@@ -191,7 +191,7 @@ spec:
 
   - name: publishingPod
     container:
-      image: keykoio/nevermined-pod-publishing-py:latest
+      image: neverminedio/pod-publishing-py:latest
       imagePullPolicy: IfNotPresent
       name: publishingPod
       command:

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,6 @@ with open('CHANGELOG.md') as history_file:
 
 install_requirements = [
     'coloredlogs',
-    'contracts-lib-py',
-    'common-utils-py==0.2.8',
     'Flask==1.1.2',
     'Flask-Cors==3.0.8',
     'flask-swagger==0.2.14',
@@ -27,7 +25,7 @@ install_requirements = [
     'PyYAML==5.3',
     'pytz',
     'web3==5.9.0',
-    'nevermined-sdk-py==0.4.0',
+    'nevermined-sdk-py==0.6.0',
 ]
 
 setup_requirements = ['pytest-runner',]


### PR DESCRIPTION
## Description

- Bump version of sdk to v0.6.0
- Use docker images under neverminedio instead of keykoio

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/internal/issues/109

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation